### PR TITLE
Add Hermes Connector to Browser Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Browser extensions that use artificial intelligence to help you write, research,
 
 - [Claude](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) - Anthropic's AI assistant as a browser agent that navigates websites, fills forms, extracts data, and runs multi-step workflows.
 - [dassi](https://chromewebstore.google.com/detail/dassi-ai-browser-agent/bjcngahpcjeililljmfegmlanlpgibdi) - AI browser agent that reads pages, fills forms, navigates sites, and completes multi-step workflows using Claude, GPT, or Gemini.
+- [Hermes Connector — by Corsen AI](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm) - open-source Chrome extension that routes an exact Hermes Agent profile and session to user-selected tabs for local-first browser control.
 - [Nanobrowser](https://github.com/nanobrowser/nanobrowser) - Open-source Chrome extension for AI-powered web automation using your own LLM API keys with a multi-agent system.
 
 ## Automation and Workflow


### PR DESCRIPTION
## What changed

- Added Hermes Connector — by Corsen AI to **Browser Agents**, in alphabetical order.
- Linked directly to the live Chrome Web Store listing.

## Why it fits

Hermes Connector is an open-source Chrome extension that routes an exact Hermes Agent profile and session only to tabs explicitly selected by the user. It is currently available in the Chrome Web Store and is actively maintained.

Project source and releases: https://github.com/CorsenAI/hermes-connector

## Disclosure

Corsen AI maintains and publishes Hermes Connector. This is a self-submission.

## Validation

- One extension added; no duplicate in the README or existing pull requests.
- Chrome Web Store URL returns HTTP 200.
- Description is one factual sentence, starts with lowercase text, and ends with a period.
- Only `README.md` changed, and `git diff --check` passes.
