### PR TITLE
Add Interline to Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Browser extensions that use artificial intelligence to help you write, research,
 - [DeepL](https://chromewebstore.google.com/detail/deepl-translate-and-write/cofdbpoegempjloogbagkncekinflcnj) - AI-powered translation and writing assistant supporting 30+ languages with industry-leading accuracy.
 - [Google Translate](https://chromewebstore.google.com/detail/google-translate/aapbdbdomjkkjkaonfhkkikfgjllcleb) - Instantly translate selected text or entire pages as you browse the web in 100+ languages.
 - [Immersive Translate](https://chromewebstore.google.com/detail/immersive-translate-trans/bpoadfkcbjbfhfodiogcnhhhpibjhbnh) - Bilingual translator for websites, PDFs, YouTube subtitles, ebooks, and manga using 20+ AI translation engines.
+- [Interline](https://github.com/eigenlux-ai/interline-translator) - open-source bilingual webpage and in-place draft translation with user-supplied AI models, custom prompts, and glossaries.
 
 ## Email and Communication
 


### PR DESCRIPTION
## Add extension

- [x] I have read the [contributing guidelines](https://github.com/kklt92/awesome-ai-extensions/blob/main/CONTRIBUTING.md)
- [x] The extension is currently available in a browser extension store or as an installable open-source project
- [x] The entry is in alphabetical order within its category
- [x] The description is concise, not promotional, and ends with a period
- [x] This is not a duplicate of an existing entry

**Extension name:** Interline

**Category:** Translation

**Why it belongs on this list:** Interline is an MIT-licensed Chrome extension for bilingual webpage and in-place draft translation. Its optional AI engines support user-supplied OpenAI, Anthropic, Gemini, OpenRouter, and compatible service credentials, with custom prompts and glossaries. It also includes a key-free Google Translate engine. Translation requests go directly to the selected provider; the extension has no analytics or translation relay server.

I maintain the project. This PR adds one entry after Immersive Translate, using a lowercase description ending with a period.

- [Source code and installation instructions](https://github.com/eigenlux-ai/interline-translator)
- [Chrome Web Store](https://chromewebstore.google.com/detail/mcefogikngeheopmdmaapfgpnnlgcoid)
- [Privacy policy](https://github.com/eigenlux-ai/interline-translator/blob/main/PRIVACY.md)

Checked the list and previous PRs for duplicates, and verified the store URL returns HTTP 200 with the extension's title.
